### PR TITLE
proper call to static methods

### DIFF
--- a/inc/class.npu_uploader.php
+++ b/inc/class.npu_uploader.php
@@ -10,17 +10,17 @@ require_once ( NGGALLERY_ABSPATH . '/admin/functions.php' );
 class UploaderNggAdmin extends nggAdmin {
 
 	// Public Variables
-	public $arrImageIds      = array();
-	public $arrImageNames    = array();
-	public $arrThumbReturn   = array();
+	static public $arrImageIds      = array();
+	static public $arrImageNames    = array();
+	static public $arrThumbReturn   = array();
+    static public $strGalleryPath   = '';
 	public $arrEXIF          = array();
 	public $arrErrorMsg      = array();
 	public $arrErrorMsg_widg = array();
 	public $strFileName      = '';
-	public $strGalleryPath   = '';
 	public $blnRedirectPage  = false;
 
-	function upload_images() {
+	static function upload_images() {
 		global $wpdb;
 		// Image Array
 		$imageslist = array();
@@ -41,7 +41,8 @@ class UploaderNggAdmin extends nggAdmin {
 			return;
 		}
 		// Read Image List
-		$dirlist = $this->scandir( WINABSPATH . $gallerypath );
+		$dirlist = UploaderNggAdmin::scandir(WINABSPATH . $gallerypath);
+
 		foreach( $_FILES as $key => $value ) {
 			if ( $_FILES[$key]['error'] == 0 ) {
 				$entropy = '';
@@ -75,10 +76,10 @@ class UploaderNggAdmin extends nggAdmin {
 				// Save Temporary File
 				if ( !@move_uploaded_file( $_FILES[$key]['tmp_name'], $dest_file ) ) {
 					self::show_error( __( 'Error, the file could not moved to: ', 'nextgen-public-uploader' ) . $dest_file );
-					$this->check_safemode( WINABSPATH.$gallerypath );
+                    self::check_safemode( WINABSPATH.$gallerypath );
 					continue;
 				}
-				if ( ! $this->chmod( $dest_file ) ) {
+				if ( ! self::chmod( $dest_file ) ) {
 					self::show_error( __( 'Error, the file permissions could not set.', 'nextgen-public-uploader' ) );
 					continue;
 				}
@@ -94,22 +95,24 @@ class UploaderNggAdmin extends nggAdmin {
 				$npu_exclude_id = 1;
 			}
 			// Add Images to Database
-			$image_ids = $this->add_Images( $galleryID, $imageslist );
-			$this->arrThumbReturn = array();
+			$image_ids = self::add_Images( $galleryID, $imageslist );
+
+            self::$arrThumbReturn = array();
+
 			foreach ( $image_ids as $pid ) {
 				$wpdb->query( "UPDATE $wpdb->nggpictures SET exclude = '$npu_exclude_id' WHERE pid = '$pid'" );
-				$this->arrThumbReturn[] = $this->create_thumbnail( $pid );
+				self::$arrThumbReturn[] = self::create_thumbnail( $pid );
 			}
-			$this->arrImageIds    = array();
-			$this->arrImageIds    = $image_ids;
-			$this->arrImageNames  = array();
-			$this->arrImageNames  = $imageslist;
-			$this->strGalleryPath = $gallerypath;
+			self::$arrImageIds    = array();
+			self::$arrImageIds    = $image_ids;
+			self::$arrImageNames  = array();
+			self::$arrImageNames  = $imageslist;
+			self::$strGalleryPath = $gallerypath;
 		}
 		return;
 	} // End Function
 
-	function upload_images_widget() {
+	static function upload_images_widget() {
 		global $wpdb;
 		// Image Array
 		$imageslist = array();
@@ -130,7 +133,7 @@ class UploaderNggAdmin extends nggAdmin {
 			return;
 		}
 		// Read Image List
-		$dirlist = $this->scandir( WINABSPATH . $gallerypath );
+		$dirlist = self::scandir( WINABSPATH . $gallerypath );
 		foreach( $_FILES as $key => $value ) {
 			if ( $_FILES[$key]['error'] == 0 ) {
 				$temp_file = $_FILES[$key]['tmp_name'];
@@ -159,10 +162,10 @@ class UploaderNggAdmin extends nggAdmin {
 				// Save Temporary File
 				if ( ! @move_uploaded_file( $_FILES[$key]['tmp_name'], $dest_file ) ) {
 					self::show_error( __( 'Error, the file could not moved to: ', 'nextgen-public-uploader' ) . $dest_file );
-					$this->check_safemode( WINABSPATH . $gallerypath );
+					self::check_safemode( WINABSPATH . $gallerypath );
 					continue;
 				}
-				if ( ! $this->chmod( $dest_file ) ) {
+				if ( ! self::chmod( $dest_file ) ) {
 					self::show_error( __( 'Error, the file permissions could not set.', 'nextgen-public-uploader' ) );
 					continue;
 				}
@@ -178,19 +181,19 @@ class UploaderNggAdmin extends nggAdmin {
 				$npu_exclude_id = 1;
 			}
 			// Add Images to Database
-			$image_ids = $this->add_Images( $galleryID, $imageslist );
-			$this->arrThumbReturn = array();
+			$image_ids = self::add_Images( $galleryID, $imageslist );
+			self::$arrThumbReturn = array();
 
 			foreach ( $image_ids as $pid ) { //TODO: prepare
 				$wpdb->query( "UPDATE $wpdb->nggpictures SET exclude = '$npu_exclude_id' WHERE pid = '$pid'" );
-				$this->arrThumbReturn[] = $this->create_thumbnail( $pid );
+				self::$arrThumbReturn[] = self::create_thumbnail($pid);
 			}
 
-			$this->arrImageIds    = array();
-			$this->arrImageIds    = $image_ids;
-			$this->arrImageNames  = array();
-			$this->arrImageNames  = $imageslist;
-			$this->strGalleryPath = $gallerypath;
+            self::$arrImageIds    = array();
+            self::$arrImageIds    = $image_ids;
+            self::$arrImageNames  = array();
+            self::$arrImageNames  = $imageslist;
+            self::$strGalleryPath = $gallerypath;
 		}
 		return;
 	} // End Function

--- a/inc/npu-upload.php
+++ b/inc/npu-upload.php
@@ -96,8 +96,9 @@ if ( ! class_exists( 'npuGalleryUpload' ) ) {
 			}
 			if ( !is_user_logged_in() && get_option( 'npu_user_role_select' ) != 99 ) {
 				$strOutput .= '<div class="need_login">';
-				if( !empty( get_option( 'npu_notlogged' ) ) ) {
-					$strOutput .= get_option( 'npu_notlogged' );
+				$notlogged = get_option( 'npu_notlogged' );
+				if( !empty( $notlogged ) ) {
+					$strOutput .= $notlogged;
 				} else {
 					$strOutput .= __( 'You must be registered and logged in to upload images.', 'nextgen-public-uploader' );
 				}
@@ -173,12 +174,12 @@ if ( ! class_exists( 'npuGalleryUpload' ) ) {
 				check_admin_referer( 'ngg_addgallery' );
 				if ( !isset( $_FILES['MF__F_0_0']['error'] ) || $_FILES['MF__F_0_0']['error'] == 0 ) {
 					$objUploaderNggAdmin = new UploaderNggAdmin();
-					$messagetext = $objUploaderNggAdmin->upload_images();
-					$this->arrImageIds = $objUploaderNggAdmin->arrImageIds;
-					$this->strGalleryPath = $objUploaderNggAdmin->strGalleryPath;
-					$this->arrImageNames = $objUploaderNggAdmin->arrImageNames;
-					if ( is_array( $objUploaderNggAdmin->arrThumbReturn ) && count( $objUploaderNggAdmin->arrThumbReturn ) > 0 ) {
-						foreach ( $objUploaderNggAdmin->arrThumbReturn as $strReturnMsg ) {
+                     UploaderNggAdmin::upload_images();
+					$this->arrImageIds = UploaderNggAdmin::$arrImageIds;
+					$this->strGalleryPath = UploaderNggAdmin::$strGalleryPath;
+					$this->arrImageNames = UploaderNggAdmin::$arrImageNames;
+					if ( is_array( UploaderNggAdmin::$arrThumbReturn ) && count( UploaderNggAdmin::$arrThumbReturn ) > 0 ) {
+						foreach ( UploaderNggAdmin::$arrThumbReturn as $strReturnMsg ) {
 							if ( $strReturnMsg != '1' ) {
 								$this->arrErrorMsg[] = $strReturnMsg;
 							}
@@ -400,13 +401,15 @@ if ( ! class_exists( 'npuGalleryUpload' ) ) {
 				if ( ! isset( $_FILES['MF__F_0_0']['error'] ) || $_FILES['MF__F_0_0']['error'] == 0 ) {
 
                     $objUploaderNggAdmin    = new UploaderNggAdmin();
-                    $messagetext            = $objUploaderNggAdmin->upload_images_widget();
-                    $this->arrImageIds      = $objUploaderNggAdmin->arrImageIds;
-                    $this->strGalleryPath   = $objUploaderNggAdmin->strGalleryPath;
-                    $this->arrImageNames    = $objUploaderNggAdmin->arrImageNames;
 
-					if ( is_array( $objUploaderNggAdmin->arrThumbReturn ) && count( $objUploaderNggAdmin->arrThumbReturn ) > 0 ) {
-						foreach ( $objUploaderNggAdmin->arrThumbReturn as $strReturnMsg ) {
+                    UploaderNggAdmin::upload_images_widget();
+                    $this->arrImageIds      = UploaderNggAdmin::$arrImageIds;
+                    $this->strGalleryPath   = UploaderNggAdmin::$strGalleryPath;
+                    $this->arrImageNames    = UploaderNggAdmin::$arrImageNames;
+
+
+					if ( is_array( UploaderNggAdmin::$arrThumbReturn ) && count( UploaderNggAdmin::$arrThumbReturn ) > 0 ) {
+						foreach ( UploaderNggAdmin::$arrThumbReturn as $strReturnMsg ) {
 							if ( $strReturnMsg != '1' ) {
 								$this->arrErrorMsg_widg[] = $strReturnMsg;
 							}

--- a/nextgen-public-uploader.php
+++ b/nextgen-public-uploader.php
@@ -3,7 +3,7 @@
 Plugin Name: NextGEN Public Uploader
 Plugin URI: http://webdevstudios.com/plugin/nextgen-public-uploader/
 Description: NextGEN Public Uploader is an extension to NextGEN Gallery which allows frontend image uploads for your users.
-Version: 1.8
+Version: 1.8.2
 Author: WebDevStudios
 Author URI: http://webdevstudios.com
 Text Domain: nextgen-public-uploader
@@ -90,7 +90,8 @@ if ( ! class_exists( 'nggLoader' ) ) {
 	include_once( dirname (__FILE__) . '/tinymce/tinymce.php' );
 
 	// Output NextGEN Public Uploader Link Love in footer
-	if ( !empty( get_option( 'npu_image_link_love' ) ) ) {
+	$linklove = get_option( 'npu_image_link_love' );
+	if ( !empty( $linklove ) ) {
 		add_action('wp_footer', 'npu_link_love');
 	}
 	function npu_link_love() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: WDS-Scott, williamsba1, rzen, webdevstudios, tw2113, JustinSainton
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3084056
 Tags: nextgen public uploader,nextgen uploader,nextgen gallery,nextgen,gallery,image,upload,photo,picture,visitor,public,uploader
 Requires at least: 3.4
-Tested up to: 3.7
-Stable tag: 1.8
+Tested up to: 3.8
+Stable tag: 1.8.2
 
 NextGEN Public Uploader is an extension to NextGEN Gallery which allows frontend image uploads for your users.
 
@@ -70,6 +70,14 @@ If you have installed NextGEN Gallery, please make sure that it is activated.
 [NextGEN Public Uploader Support](http://wordpress.org/support/plugin/nextgen-public-uploader)
 
 == Changelog ==
+
+= V1.8.2 - 01.10.2014 =
+* Running fine on PHP strict mode
+* Fixed: method called as static an vice-versa improved
+* Plugin works ok with NextCellent plugin
+
+= V1.8.1 - 11.14.2013 =
+* Fix old php version bug with empty()
 
 = V1.8 - 11.14.2013 =
 * Converted widget to proper widget class extension.


### PR DESCRIPTION
Hi there!
I'm currently developing the NextCellent Gallery plugin and I found current Version NextGen Public Uploader is working fine with NextCellent. I tested the features and it is absolutely great!

The current request is trying to workaround a few issues since I'm working on PHP strict mode. I tried to be sure to call static methods properly without containing $this references.

What I did was simply activate strict mode and modify the plugin until there were no more error nor warnings.
Please notice the plugin was tested with NextCellent, but I didn't tested it with NextGen.

Also , this plugin allowed me to find two NextCellent errors due improper class use.
Please check if the concept is right for you and keep the good work!
